### PR TITLE
muiltiday events support

### DIFF
--- a/dev-demo/app.vue
+++ b/dev-demo/app.vue
@@ -2,7 +2,8 @@
     <div class="container">
         <FullCalendar />
         <Card
-            v-for="(item, i) in lists()" :key="item.value"
+            v-for="item in lists()"
+            :key="item.value"
             :image-url="item.imageURL"
             :label="item.label"
             :desc="item.desc"
@@ -29,13 +30,13 @@ export default {
                 {
                     imageURL: "https://upload.wikimedia.org/wikipedia/en/thumb/5/58/Breathe_%28Web_series%29_poster.jpg/220px-Breathe_%28Web_series%29_poster.jpg",
                     label: "Saman",
-                    value: 20,
+                    value: 21,
                     desc: "<ul><li>15 task pending</li><li>25 task Remaining</ul></ul>",
                 }
-            ]
+            ];
         }
     }
-}
+};
 </script>
 <style lang="scss">
     @import "../src/styles/index.scss";

--- a/src/components/full-calendar/src/calendar.vue
+++ b/src/components/full-calendar/src/calendar.vue
@@ -20,9 +20,10 @@
             </div>
             <div
                 class="event"
-                v-for="event in getDateEvents(dayNumber)"
+                :class="getBorderRadius(getDateEvents(dayNumber).date, dayNumber)"
+                v-for="event in getDateEvents(dayNumber).events"
                 :key="event.label"
-                :style="{ ...event.styles, width: `${event.numberOfDays * 100}%` }"
+                :style="event.styles"
             >
                 {{ event.label }}
                 <span class="event-icon">
@@ -54,7 +55,6 @@ export default {
     data() {
         return {
             activeDayNumber: null,
-            traversedHistory: [],
         };
     },
     props: {
@@ -95,32 +95,33 @@ export default {
         },
         getDateEvents(dayNumber) {
             const currentDate = new Date(this.year, this.month, dayNumber);
-            let numberOfDays = 1;
             const currentDateEvents = this.dateEvents.find(data => {
                 let fromDate = new Date();
                 let toDate = new Date();
                 if (isJSON(data.date)) {
                     fromDate = new Date(data.date.from);
                     toDate = new Date(data.date.to);
-                    numberOfDays = Math.floor((toDate - fromDate)/(3600000 * 24)) + 1;
                     return currentDate >= fromDate && currentDate <= toDate;
                 }
-                return new Date(data.date) === currentDate;
+                return new Date(data.date).toLocaleString() === currentDate.toLocaleString();
 
             }) || dateEventsInterface;
-            // filter out already traversed events using traversedHistory
-            const events = currentDateEvents.events
-                .filter(event => !this.traversedHistory.includes(event.id))
-                .map(event => ({ ...event, numberOfDays }));
-            this.insertEventsToTraversal(events);
-            return events;
+            return currentDateEvents;
         },
-        insertEventsToTraversal(events) {
-            // create a history array with unique id of traversed events
-            this.traversedHistory = [...this.traversedHistory, ...events.map(event => event.id)];
-            this.traversedHistory = Array.from(
-                new Set([...this.traversedHistory, ...events.map(event => event.id)])
-            );
+        getBorderRadius(date, dayNumber) {
+            if (!date.from) return "border-rounded-left-right";
+
+            if (new Date(date.from).toDateString() === new Date(date.to).toDateString())
+                return "border-rounded-left-right";
+
+            const currentDate = new Date(this.year, this.month, dayNumber);
+            if (currentDate.toDateString() === new Date(date.from).toDateString()) {
+                return "border-rounded-left";
+            }
+            if (currentDate.toDateString() === new Date(date.to).toDateString()) {
+                return "border-rounded-right";
+            }
+            return "";
         },
         getDayName(dayNumber) {
             const dayIndex = new Date(this.year, this.month, dayNumber).getDay();

--- a/src/components/full-calendar/src/index.vue
+++ b/src/components/full-calendar/src/index.vue
@@ -23,7 +23,7 @@
 <script>
 import Calendar from "./calendar";
 import Card from "@/components/card";
-import months from '@/components/interface/months';
+import months from "@/components/interface/months";
 
 
 const items = [
@@ -32,8 +32,9 @@ const items = [
             value: 220,
             dateEvents: [
             {
-                date: { from: "2020/07/21", to: "2020/07/25" },
+                date: { from: "2020/08/21", to: "2020/08/25" },
                 events: [{
+                    id: 1,
                     name: "s",
                     label: "20%",
                     styles: {
@@ -49,8 +50,9 @@ const items = [
         desc: "<ul><li>15 task pending</li><li>25 task Remaining</li></ul>",
         dateEvents: [
             {
-            date: { from: "2020/07/11", to: "2020/07/13" },
+            date: { from: "2020/08/11", to: "2020/08/14" },
             events: [{
+                id: 2,
                 name: "Tasks",
                 icon: "⭐",
                 styles: {
@@ -60,6 +62,7 @@ const items = [
                 }
             },
             {
+                id: 3,
                 name: "Sales",
                 styles: {
                     backgroundColor: "green",
@@ -69,14 +72,16 @@ const items = [
             }]
         },
         {
-        date: { from: "2020/07/14", to: "2020/07/16" },
+        date: { from: "2020/08/15", to: "2020/08/16" },
         events: [
         {
+            id: 4,
             name: "Tasks",
             styles: {
-                backgroundColor: "red",
+                backgroundColor: "blue",
                 marginLeft: "-1px",
-                marginRight: "-1px"
+                marginRight: "-1px",
+                borderRadius: "5px"
             }
         }]
     }]
@@ -87,8 +92,9 @@ const items = [
         value: 10,
         desc: "<ul><li>15 task pending</li><li>25 task Remaining</li></ul>",
         dateEvents: [{
-            date: { from: "2020/07/3", to: "2020/07/10" },
+            date: { from: "2020/08/3", to: "2020/08/10" },
             events: [{
+                id: 5,
                 groupName: "Tasks",
                     styles: {
                         backgroundColor: "blue",
@@ -98,8 +104,9 @@ const items = [
                 }],
             },
             {
-            date: { from: "2020/07/12", to: "2020/07/18" },
+            date: { from: "2020/08/12", to: "2020/08/18" },
             events: [{
+                id: 6,
                 groupName: "Tasks",
                 styles: {
                     backgroundColor: "red",

--- a/src/components/full-calendar/src/index.vue
+++ b/src/components/full-calendar/src/index.vue
@@ -80,8 +80,7 @@ const items = [
             styles: {
                 backgroundColor: "blue",
                 marginLeft: "-1px",
-                marginRight: "-1px",
-                borderRadius: "5px"
+                marginRight: "-1px"
             }
         }]
     }]

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -26,17 +26,50 @@ p {
     border: 1px solid #ddd;
     max-width: 50px;
     min-width: 50px;
+    display: flex;
+    flex-direction: column;
 }
 .event {
-    height: 20px;
+    height: 10px;
     background: white;
     margin-top: 10px;
-    border-radius: 20px;
-};
-.event-icon {
     position: relative;
-    top: -16px;
-    margin-left: 20px;
+};
+.border-rounded-left {
+    border-top-left-radius: 20px;
+    border-bottom-left-radius: 20px;
+    width: 85%;
+    align-self: flex-end;
+    .event-icon {
+        top: -9px;
+        left: 5px;
+        right: 0px;
+    }
+}
+.border-rounded-right {
+    border-top-right-radius: 20px;
+    border-bottom-right-radius: 20px;
+    width: 85%;
+    align-self: flex-start;
+    .event-icon {
+        top: -9px;
+        right: 0px;
+        left: 16px;
+    }
+}
+.border-rounded-left-right {
+    border-radius: 20px;
+    width: 85%;
+    align-self: center;
+    .event-icon {
+        top: -9px;
+        left: 14px;
+    }
+}
+.event-icon {
+    position: absolute;
+    top: -9px;
+    left: 18px;
 }
 .card-header {
     display: grid;


### PR DESCRIPTION
**Summary:**  
* Multiday events were rendered as individual day events. Changed the way they render by adding a traversalHistory data where ids of events which are already traversed are inserted. If those events are found later, they are not rendered. Number of days of event is calculated for calculating the scale of the event bar. If an event goes on for 3 days, the width of the event bar is `(3 * 100)%` and so on.  
* Some minor lint fixes
* Changed dummy data from july to august.